### PR TITLE
remove odgi dependency and fix minor bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,28 @@ bellow is a schematic representation of the PG-SCUnK workflow, please read the a
 ### Install the dependances in a dedicated environment.
 
 PG-SCUnK requires _KMC_ to be installed and available in your `$PATH`.
-Companions scripts require _samtools_ and _odgi_ for **_GFA2HaploFasta.bash_** and _zlib_ and _R_ for **_PG-SCUnK_plot.R_**
+Companions scripts require _samtools_ for **_GFA2HaploFasta.bash_** and _zlib_ and _R_ for **_PG-SCUnK_plot.R_**
 
 All the dependence can be installed by running:
 
 ```
 # Using mamba 
-mamba install bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0 
+mamba install bioconda::kmc=3.2.4 bioconda::samtools=1.21 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0 
 
 # Using conda
-# conda install bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0
+# conda install bioconda::kmc=3.2.4 bioconda::samtools=1.21 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0
 ```
 
 Creating a dedicated environment is a convenient way to ensure no interference with other software.
 
 ```
 # Using mamba 
-mamba create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0
+mamba create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0
 # then load the evironement before running PG-SCUnK with:
 mamba activate PG-SCUnK-env
 
 # Using conda
-# conda create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0 
+# conda create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0 
 # conda activate PG-SCUnK-env
 ```
 
@@ -132,8 +132,8 @@ This script is useful to extract the assemblies from a graph. **Before using it,
 
 `Usage: ./scripts/GFA2HaploFasta.bash -p <panGenome.gfa> -t <tempDir> -o <outDir> -@ <threads>`
 
-this script requires _samtools_ and _odgi_ to be present in you path. you can install them in the environment using: 
-`mamba install -n PG-SCUnK-env bioconda::samtools=1.21 bioconda::odgi=0.9.0`
+this script requires _samtools_ to be present in you path. you can install them in the environment using: 
+`mamba install -n PG-SCUnK-env bioconda::samtools=1.21`
 
 **`scripts/PG-SCUnK_plot.R`**
 

--- a/scripts/GFA2HaploFasta.bash
+++ b/scripts/GFA2HaploFasta.bash
@@ -49,7 +49,7 @@ extract_gfa_fasta() {
               if(o=="+") {printf N[n]} else {printf revcomp(N[n])} };  printf "\n" }}' ${PG}
 }
 
-extract_gfa_fasta > ${TEMPDIR}/${RandName}.full.fa#odgi paths -t ${THREADS} -f -i ${PG} > ${TEMPDIR}/${RandName}.full.fa
+extract_gfa_fasta > ${TEMPDIR}/${RandName}.full.fa
 
 # Index the panGenome fasta using samtools
 # Assuming samtools is available, loading necessary modules


### PR DESCRIPTION
GFAs are easy enough to parse (assuming paths come last) without using odgi. This should allow `PG-SCUnK` to be used on MacOS and aarch64 since `odgi` was only available for linux-64, whereas `samtools` and `KMC` are more widely available.

The awk parsing will only break if there are "S" lines _after_ "P" lines in the GFA, which I don't think is required by spec, but probably universally common.