### PR TITLE
Use conda environment definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ All the dependence can be installed by running:
 
 ```
 # Using mamba 
-mamba install bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0 
+mamba install bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 conda-forge::r-base=4.2.0 
 
 # Using conda
-# conda install bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0
+# conda install bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 conda-forge::r-base=4.2.0
 ```
 
 Creating a dedicated environment is a convenient way to ensure no interference with other software.
 
 ```
 # Using mamba 
-mamba create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0
+mamba create -f environment.yaml
 # then load the evironement before running PG-SCUnK with:
 mamba activate PG-SCUnK-env
 
 # Using conda
-# conda create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 bioconda::r-base=4.2.0 
+# conda create -f environment.yaml
 # conda activate PG-SCUnK-env
 ```
 
@@ -134,12 +134,14 @@ This script is useful to extract the assemblies from a graph. **Before using it,
 
 this script requires _samtools_ and _odgi_ to be present in you path. you can install them in the environment using: 
 `mamba install -n PG-SCUnK-env bioconda::samtools=1.21 bioconda::odgi=0.9.0`
+or using the existing *PG-SCUnK-env* environment.
 
 **`scripts/PG-SCUnK_plot.R`**
 
 this script uses _R_ to make a triangular plot for a given a `.stats.txt` output file from PG-SCUnK.
 You can install _R_ in the environment using : 
 `mamba install -n PG-SCUnK-env bioconda::samtools=1.21 bioconda::R=0.9.0`
+or using the existing *PG-SCUnK-env* environment.
 
 ---
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,9 @@
+name: PG-SCUnK-env
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - kmc=3.2.4
+  - samtools=1.21
+  - r-base=4.2


### PR DESCRIPTION
`r-base` is actually from conda-forge not bioconda, but even after changing that I could not install on Euler or my laptop. This adds an explicit environment file we can install from, making it easier to track dependencies rather than through the readme. I also removed the zlib dependency since it will be auto-determined by conda/mamba and we do not use zlib directly.