### PR TITLE
Add github action to test validity of install+execution

### DIFF
--- a/.github/workflows/PG-SCUnK.yaml
+++ b/.github/workflows/PG-SCUnK.yaml
@@ -14,7 +14,7 @@ jobs:
             bioconda::samtools=1.21
             bioconda::odgi=0.9.0
             conda-forge::zlib=1.3.1
-            conda-forge::r-basepython=3.10
+            conda-forge::r-base
       - name: Run
         run: |
              wget https://zenodo.org/records/7937947/files/ecoli50.gfa.zst

--- a/.github/workflows/PG-SCUnK.yaml
+++ b/.github/workflows/PG-SCUnK.yaml
@@ -24,4 +24,9 @@ jobs:
              mkdir TEMP
              bash scripts/GFA2HaploFasta.bash -p ecoli50.gfa -t TEMP -o ecoli50 -@ 1
              bash PG-SCUnK -p ecoli50.gfa -a ecoli50 -o Out_PG-SCUnK/ecoli50 -t TEMP -k 100
+             if md5sum --status -c <(echo -e "fae38b458a2f79bc6935092f61560785  Out_PG-SCUnK/ecoli50.all.txt\nc9c77a91722d14b7cf91241f15b8f1e8  Out_PG-SCUnK/ecoli50.colapsed.txt\n0328efc2c82f53415cc023060caeaaf3  Out_PG-SCUnK/ecoli50.duplicated.txt\n808a1bbddd88a48e1ee2952991a48d18  Out_PG-SCUnK/ecoli50.stats.txt\n1f35e73a4a9e07b0523b0ded01b83aee  Out_PG-SCUnK/ecoli50.unique.txt"); then
+               echo "Test passed!"
+             else
+               exit 1
+             fi
         shell: bash -el {0}

--- a/.github/workflows/PG-SCUnK.yaml
+++ b/.github/workflows/PG-SCUnK.yaml
@@ -15,10 +15,13 @@ jobs:
             bioconda::odgi=0.9.0
             conda-forge::zlib=1.3.1
             conda-forge::r-base
+          init-shell: >-
+            bash 
       - name: Run
         run: |
-             wget https://zenodo.org/records/7937947/files/ecoli50.gfa.zst
+             wget -q https://zenodo.org/records/7937947/files/ecoli50.gfa.zst
              unzstd ecoli50.gfa.zst 
              mkdir TEMP
              bash scripts/GFA2HaploFasta.bash -p ecoli50.gfa -t TEMP -o ecoli50 -@ 1
              bash PG-SCUnK -p ecoli50.gfa -a ecoli50 -o Out_PG-SCUnK/ecoli50 -t TEMP -k 100
+        shell: bash -el {0}

--- a/.github/workflows/PG-SCUnK.yaml
+++ b/.github/workflows/PG-SCUnK.yaml
@@ -1,0 +1,24 @@
+name: PG-SCUnK
+on:
+  workflow_dispatch
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: PG-SCUnK-env
+          create-args: >-
+            bioconda::kmc=3.2.4
+            bioconda::samtools=1.21
+            bioconda::odgi=0.9.0
+            conda-forge::zlib=1.3.1
+            conda-forge::r-basepython=3.10
+      - name: Run
+        run: |
+             wget https://zenodo.org/records/7937947/files/ecoli50.gfa.zst
+             unzstd ecoli50.gfa.zst 
+             mkdir TEMP
+             bash scripts/GFA2HaploFasta.bash -p ecoli50.gfa -t TEMP -o ecoli50 -@ 1
+             bash PG-SCUnK -p ecoli50.gfa -a ecoli50 -o Out_PG-SCUnK/ecoli50 -t TEMP -k 100

--- a/PG-SCUnK
+++ b/PG-SCUnK
@@ -97,7 +97,7 @@ for FILE in ${input_assemblies_directory}/*.fasta; do
 
   # Extract kmers for the current file
   temp_kmer_db="${temp_directory}/${RandName}/$NAME"
-  kmc -t1 -cm -k"$kmer_size" -ci0 -cx1 -fm "$FILE" "$temp_kmer_db" "${temp_directory}/${RandName}/" > $output_base.log out 2>&1
+  kmc -hp -t1 -cm -k"$kmer_size" -ci0 -cx1 -fm "$FILE" "$temp_kmer_db" "${temp_directory}/${RandName}/" > $output_base.log out 2>&1
 
   if $first_file; then
     # First file: copy kmer database to initialize the intersection file
@@ -108,7 +108,7 @@ for FILE in ${input_assemblies_directory}/*.fasta; do
   else
     # Perform intersection with the current kmer set
     next_intersect_file="${temp_directory}/${RandName}/intersect_temp_$NAME"
-    kmc_tools -t1 -v simple "$intersect_file" "$temp_kmer_db" intersect "$next_intersect_file"  # >> $output_base.log out 2>&1
+    kmc_tools -hp -t1 -v simple "$intersect_file" "$temp_kmer_db" intersect "$next_intersect_file"  # >> $output_base.log out 2>&1
 
     # Clean up previous intersection files after generating the new one
     rm "$temp_kmer_db.kmc_suf" "$temp_kmer_db.kmc_pre"
@@ -127,7 +127,7 @@ final_kmer_file="${temp_directory}/${RandName}/${RandName}_allUniqKmers"
 mv "$intersect_file.kmc_suf" "$final_kmer_file.kmc_suf"
 mv "$intersect_file.kmc_pre" "$final_kmer_file.kmc_pre"
 
-kmc_tools -t1 transform "$final_kmer_file" dump "$output_base.all.txt" # >> $output_base.log out 2>&1
+kmc_tools -hp -t1 transform "$final_kmer_file" dump "$output_base.all.txt" # >> $output_base.log out 2>&1
 
 # Clean up final temporary intersection file
 # rm "$final_kmer_file.kmc_suf" "$final_kmer_file.kmc_pre"
@@ -146,7 +146,7 @@ echo  "[$((`date +%s`-start)) sec] Extracting K-mers from the Graph ... "
 awk '$1=="S" {print ">"$2"\n"$3}' ${input_gfa_file} > ${temp_directory}/${RandName}/${RandName}.graphnodes.fa
 
 # Kmer count from the graph nodes
-kmc -t1 -cm -k"$kmer_size" -fm -ci0 "${temp_directory}/${RandName}/${RandName}.graphnodes.fa" "${temp_directory}/${RandName}/${RandName}.graphnodes" "${temp_directory}/${RandName}/"  >> $output_base.log out 2>&1
+kmc -hp -t1 -cm -k"$kmer_size" -fm -ci0 "${temp_directory}/${RandName}/${RandName}.graphnodes.fa" "${temp_directory}/${RandName}/${RandName}.graphnodes" "${temp_directory}/${RandName}/"  >> $output_base.log out 2>&1
 
 echo  "[$((`date +%s`-start)) sec] Extracting K-mers from the Graph : DONE"
 
@@ -158,16 +158,16 @@ echo  "[$((`date +%s`-start)) sec] Extracting K-mers from the Graph : DONE"
 echo  "[$((`date +%s`-start)) sec] Comparing Single Copy and Unversal Kmers with kmers from the graph ..."
 
 # Run KMC tools for intersect & identify unique kmers presents 1 time in the graph
-kmc_tools -t1 simple "${temp_directory}/${RandName}/${RandName}_allUniqKmers" "${temp_directory}/${RandName}/${RandName}.graphnodes" -cx1 intersect "${temp_directory}/${RandName}/${RandName}.unique"
-kmc_tools -t1 transform "${temp_directory}/${RandName}/${RandName}.unique" dump "$output_base.unique.txt"
+kmc_tools -hp -t1 simple "${temp_directory}/${RandName}/${RandName}_allUniqKmers" "${temp_directory}/${RandName}/${RandName}.graphnodes" -cx1 intersect "${temp_directory}/${RandName}/${RandName}.unique"
+kmc_tools -hp -t1 transform "${temp_directory}/${RandName}/${RandName}.unique" dump "$output_base.unique.txt"
 
 # Run KMC tools for intersect & identify unique kmers presents 2 or more times in the graph
-kmc_tools -t1 simple "${temp_directory}/${RandName}/${RandName}_allUniqKmers" "${temp_directory}/${RandName}/${RandName}.graphnodes" -ci2 intersect "${temp_directory}/${RandName}/${RandName}.duplicated"
-kmc_tools -t1 transform "${temp_directory}/${RandName}/${RandName}.duplicated" dump "$output_base.duplicated.txt"
+kmc_tools -hp -t1 simple "${temp_directory}/${RandName}/${RandName}_allUniqKmers" "${temp_directory}/${RandName}/${RandName}.graphnodes" -ci2 intersect "${temp_directory}/${RandName}/${RandName}.duplicated"
+kmc_tools -hp -t1 transform "${temp_directory}/${RandName}/${RandName}.duplicated" dump "$output_base.duplicated.txt"
 
 # Run KMC tools for intersect & identify unique kmers presents 2 or more times in the graph
-kmc_tools -t1 simple "${temp_directory}/${RandName}/${RandName}_allUniqKmers" "${temp_directory}/${RandName}/${RandName}.graphnodes" kmers_subtract "${temp_directory}/${RandName}/${RandName}.colapsed"
-kmc_tools -t1 transform "${temp_directory}/${RandName}/${RandName}.colapsed" dump "$output_base.colapsed.txt"
+kmc_tools -hp -t1 simple "${temp_directory}/${RandName}/${RandName}_allUniqKmers" "${temp_directory}/${RandName}/${RandName}.graphnodes" kmers_subtract "${temp_directory}/${RandName}/${RandName}.colapsed"
+kmc_tools -hp -t1 transform "${temp_directory}/${RandName}/${RandName}.colapsed" dump "$output_base.colapsed.txt"
 
 echo  "[$((`date +%s`-start)) sec] Comparing Sets of Kmers : DONE"
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 ![](images/PG-SCUnK_logo.png)
 
+**P**an**G**enome **S**ingle **C**opy and **Un**iversal **K**mer counter (**PG-SCUnK**) aims to measure pan-genome graph quality using single-copy and universal *k*-mers.  
+We assume that single-copy *k*-mers found in an assembly and universally present across all assemblies are orthologous, and should be found uniquely and in their full length in the nodes of the graph.
 
-**P**an**G**enome **S**ingle **C**opy and **Un**iversal **K**mer counter (**PG-SCUnK**) aims to measure pan-genome graph quality using single-copy and universal K-mers.  
-We assume that single-copy k-mers found in an assembly and universally present across all assemblies are orthologous, and should be found uniquely and in their full length in the nodes of the graph.
-
-We thus propose simple metrics to describe a pan-genome graph based on the proportion of single-copy and universal K-mers composing the assemblies that are:
+We thus propose simple metrics to describe a pan-genome graph based on the proportion of single-copy and universal *k*-mers composing the assemblies that are:
 - _**Unique**_: Present only once and in full length in one of the nodes of the graph.
 - _**Duplicated**_: Present multiple times in the graph.
 - _**Collapsed**_: Fragmented over different nodes due to the aggregation of non-orthologous sequences.
 
-The pipeline relies on [KMC](https://github.com/refresh-bio/KMC) to identify single-copy K-mers shared by all the assemblies (i.e., universal) composing a pan-genome graph.
+The pipeline relies on [KMC](https://github.com/refresh-bio/KMC) to identify single-copy *k*-mers shared by all the assemblies (i.e., universal) composing a pan-genome graph.
 
-bellow is a schematic representation of the PG-SCUnK workflow, please read the associated publication for details.
+bellow is a schematic representation of the `PG-SCUnK` workflow, please read the associated publication for details.
 
 ![](images/PG-SCUnK_workflow.png)
 
@@ -19,9 +18,9 @@ bellow is a schematic representation of the PG-SCUnK workflow, please read the a
 
 ## 1. Installation
 
-### Install the dependances in a dedicated environment.
+### Install the dependencies in a dedicated environment.
 
-PG-SCUnK requires _KMC_ to be installed and available in your `$PATH`.
+`PG-SCUnK` requires `kmc` and `kmc_tools`  to be installed and available in your `$PATH`.
 Companions scripts require _samtools_ and _odgi_ for **_GFA2HaploFasta.bash_** and _zlib_ and _R_ for **_PG-SCUnK_plot.R_**
 
 All the dependence can be installed by running:
@@ -39,7 +38,8 @@ Creating a dedicated environment is a convenient way to ensure no interference w
 ```
 # Using mamba 
 mamba create -n PG-SCUnK-env bioconda::kmc=3.2.4 bioconda::samtools=1.21 bioconda::odgi=0.9.0 conda-forge::zlib=1.3.1 conda-forge::r-base
-# then load the evironement before running PG-SCUnK with:
+# then load the environment before running PG-SCUnK with:
+
 mamba activate PG-SCUnK-env
 
 # Using conda
@@ -49,7 +49,7 @@ mamba activate PG-SCUnK-env
 
 ### clone the directory
 
-Download PG-SCUnK:
+Download `PG-SCUnK`:
 
 ```
 git clone https://github.com/cumtr/PG-SCUnK.git
@@ -57,7 +57,7 @@ git clone https://github.com/cumtr/PG-SCUnK.git
 
 ### test run
 
-To test PG-SCUnK, run:
+To test `PG-SCUnK`, run:
 
 ```
 cd PG-SCUnK
@@ -65,22 +65,22 @@ chmod +x ./PG-SCUnK
 ./PG-SCUnK
 ```
 
-This command should print the help line for PG-SCUnK:
+This command should print the help line for `PG-SCUnK`:
 
 `Usage: ./PG-SCUnK -p <panGenome> -a <path/to/assemblies/> -o <outputDir/outputBasename> -t <WorkDir> (-k <kmer_size> -v)`
 
 ---
 
-## 2. Run PG-SCUnK
+## 2. Running PG-SCUnK
 
 To run, PG-SCUnK require four informations:
-- **`-p`** Point to the graph in `.gfa` format
-- **`-a`** Point to the directory where all the assemblies that compose the graph are stored (PG-SCUnK assumes all the files is this directory than ends with `.fasta` are the assemblies to consider)
-- **`-o`** Gives to PG-SCUnK the path + basename of the output file
-- **`-t`** set the working directory for PG-SCUnK to write temporary files
+- **`-p`** path to the graph in `.gfa` format
+- **`-a`** path to the directory where all the assemblies that compose the graph are stored (`PG-SCUnK` assumes all the files is this directory than ends with `.fasta` are the assemblies to consider)
+- **`-o`** the path + basename of the output file
+- **`-t`** the working directory for `PG-SCUnK` to write temporary files
 
 two other optional parameters can be provided: 
-- **`-k`** is used to give to PG-SCUnK the k-mer size to use. default value is 100.
+- **`-k`** sets the *k*-mer size for `PG-SCUnK` use. default value is 100.
 - **`-v`** state for the level of verbose. adding this flag (no values expected) make PG-SCUnK really verbose. mostly useful for debugging.
 
 A typical command would be:
@@ -91,45 +91,45 @@ A typical command would be:
 
 This command produces five distinct files:
 
-- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.stats.txt` : Contains counts of _**single-copy and universal**_ K-mers, _**unique**_ K-mers, _**duplicated**_ K-mers, and _**collapsed**_ K-mers in the graph.
+- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.stats.txt` : Contains counts of _**single-copy and universal**_ *k*-mers, _**unique**_ *k*-mers, _**duplicated**_ *k*-mers, and _**collapsed**_ *k*-mers in the graph.
 
-the four other files report the k-mers for the different categories:
+the four other files report the *k*-mers for the different categories:
 
-- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.all.txt`: List of all _**Single-Copy and Universal**_ K-mers.
-- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.unique.txt`: List of _**unique**_ K-mers.
-- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.duplicated.txt`: List of _**duplicated**_ K-mers.
-- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.collapsed.txt`: List of _**collapsed**_ K-mers.
+- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.all.txt`: List of all _**Single-Copy and Universal**_ *k*-mers.
+- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.unique.txt`: List of _**unique**_ *k*-mers.
+- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.duplicated.txt`: List of _**duplicated**_ *k*-mers.
+- `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.collapsed.txt`: List of _**collapsed**_ *k*-mers.
 - `./OutputPG-SCUnK/MyPanGenomeGraph.PG-SCUnK.log`: log file.
 
 ---
 
-## Chosing the best k-mer size
+## Choosing the best *k*-mer size
 
-The **`-k`** parameter, which sets the k-mer size, is the only parameter that the user can specify in the PG-SCUnK workflow.
+The **`-k`** parameter, which sets the *k*-mer size, is the only parameter that the user can specify in the PG-SCUnK workflow.
 Choosing the best possible k requires understanding a few key aspects of how PG-SCUnK works.
 
 **Even or Odd?**
 
-Unlike many programs, PG-SCUnK does not require k-mers to be odd. This is because it uses canonical k-mers: any k-mer and its reverse complement are treated as the same unique k-mer, regardless of their length.
+Unlike many programs, `PG-SCUnK` does not require *k*-mers to be odd. This is because it uses canonical *k*-mers: any *k*-mer and its reverse complement are treated as the same unique *k*-mer, regardless of their length.
 
 **Not too big, Not too small**
 
-In our tests (see the associated publication for details), PG-SCUnK results are robust to k-mer size as long as the size is not too large.
-When k-mers are too long, they are more likely to be broken by polymorphisms. As a result, their number decreases, reducing the genome’s representation.
-When k-mers are too short, the opposite problem occurs: they tend to lack specificity, making them less unique and less universal.
+In our tests (see the associated publication for details), `PG-SCUnK` results are robust to *k*-mer size as long as the size is not too large.
+When *k*-mers are too long, they are more likely to be broken by polymorphisms. As a result, their number decreases, reducing the genome’s representation.
+When *k*-mers are too short, the opposite problem occurs: they tend to lack specificity, making them less unique and less universal.
 
 Our tests suggest that choosing a k value between 31 and 150 provides consistent results.
 The default value, 100, performed well in our benchmarking.
 
 ---
 
-## Compagnion scripts
+## Companion scripts
 
-PG-SCUnK comes with companion scripts.
+`PG-SCUnK` comes with companion scripts.
 
 **`scripts/GFA2HaploFasta.bash`**
 
-This script is useful to extract the assemblies from a graph. **Before using it, make sure the graph was not trimmed in any way and contain the full assemblies** (row output from __pggb__ or __minigraph cactus__ for example). This script accept the graph in .gfa and .og format.
+This script is useful to extract the assemblies from a graph. **Before using it, make sure the graph was not trimmed in any way and contain the full assemblies** (raw output from `pggb` or `minigraph-cactus` for example). This script accept the graph in .gfa and .og format.
 
 `Usage: ./scripts/GFA2HaploFasta.bash -p <panGenome.gfa> -t <tempDir> -o <outDir> -@ <threads>`
 
@@ -138,7 +138,7 @@ this script requires _samtools_ and _odgi_ to be present in you path. you can in
 
 **`scripts/PG-SCUnK_plot.R`**
 
-this script uses _R_ to make a triangular plot for a given a `.stats.txt` output file from PG-SCUnK.
+this script uses _R_ to make a triangular plot for a given a `.stats.txt` output file from `PG-SCUnK`.
 You can install _R_ in the environment using : 
 `mamba install -n PG-SCUnK-env bioconda::samtools=1.21 bioconda::R=0.9.0`
 
@@ -146,7 +146,7 @@ You can install _R_ in the environment using :
 
 ## Example of workflow
 
-Here is an example of workflow to run PG-SCUnK for a pan-genome build for 50 e.coli and published [here](https://www.nature.com/articles/s41592-024-02430-3)
+Here is an example of workflow to run `PG-SCUnK` for a pan-genome build for 50 e.coli and published [here](https://www.nature.com/articles/s41592-024-02430-3)
 
 ```
 # Download and uncompress the graph in .gfa format.
@@ -170,5 +170,4 @@ Rscript --vanilla /path/to/PG-SCUnK/scripts/PG-SCUnK_plot.R Out_PG-SCUnK/ecoli50
 
 ## Licence
 
-PG-SCUnK software is distributed under [GNU GPL 3 licence](https://www.gnu.org/licenses/gpl-3.0.txt).
-
+`PG-SCUnK` software is distributed under [GNU GPL 3 license](https://www.gnu.org/licenses/gpl-3.0.txt).

--- a/scripts/GFA2HaploFasta.bash
+++ b/scripts/GFA2HaploFasta.bash
@@ -62,6 +62,6 @@ done
 # Cleanup
 rm ${TEMPDIR}/${RandName}.full.fa
 rm ${TEMPDIR}/${RandName}.full.fa.fai
-rm ${TEMPDIR}/${RandName}/ListHaplotypes.txt
+rm ${TEMPDIR}/${RandName}.ListHaplotypes.txt
 
 echo "Processing completed. Haplotypes extracted to ${OUTDIR}"


### PR DESCRIPTION
This basically wraps your test script in a github action that we can manually run to test/demonstrate everything works from a fresh install. I used micromamba as it is lightweight, and installing the Ternary R package was a pain so I skipped the plotting script. Otherwise this runs in about 3 minutes.

If you enable squash merging in the repo settings, we can add this as a single commit.

I also added `-hp` to all the `kmc` calls, as printing hundreds of progress lines for k-mer counting was unnecessary. Potentially could link the verbose flag to being verbose in KMC, but since k-mer counting is so quick here,  we don't really need progress for it. 